### PR TITLE
Fix Windows & Linux report opening error

### DIFF
--- a/analog_measurement.py
+++ b/analog_measurement.py
@@ -8,6 +8,7 @@ would be running I2C electrical test on capture data.
 import datetime
 import os
 import subprocess
+import platform
 import tempfile
 
 from generate_report import OutputReportFile
@@ -378,6 +379,14 @@ class HummingBird(AnalogMeasurer, hummingbird.HummingBird):
         fail.copy(), num_pass, svg_fields, uni_addr, sampling_rate,
         waveform_info, LOCAL_PATH
     )
-    subprocess.run(["open", report_path], check=True)
+    open_file(report_path)
 
     return values
+
+def open_file(filepath):
+    if platform.system() == 'Darwin':       # macOS
+        subprocess.call(('open', filepath))
+    elif platform.system() == 'Windows':    # Windows
+        os.startfile(filepath)
+    else:                                   # linux variants
+        subprocess.call(('xdg-open', filepath))


### PR DESCRIPTION
Fixes #28 

Problem: "open" command only exists on MacOS.

Solution: add a helper function to use the correct platform specific method for opening a file.

Manually tested on Windows.
I have not re-tested on MacOS, and I've never tested this on Linux.